### PR TITLE
Fix: Remove manual font preload to resolve 404 error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,15 +53,7 @@ const { data: profile } = user
 
   return (
     <html lang="en" suppressHydrationWarning className={inter.variable}>
-      <head>
-        <link
-          rel="preload"
-          href="/_next/static/media/inter-latin.woff2"
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
-      </head>
+      <head />
       <body className={`${inter.className} antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange={false}>
           <div className="relative flex min-h-screen flex-col">


### PR DESCRIPTION
Removes a hardcoded `<link rel="preload">` tag for the Inter font from the root layout. This link was pointing to an incorrect path, causing a 404 error on all pages.

The Next.js `next/font` optimization already in place handles font loading automatically, making the manual link unnecessary. Removing it resolves the 404 error and relies on the framework's intended font handling mechanism.